### PR TITLE
Empty buffers are now tracked until opening new file unless modified

### DIFF
--- a/lua/streamline/core.lua
+++ b/lua/streamline/core.lua
@@ -12,7 +12,7 @@ end
 function M:init()
 	vim.api.nvim_create_autocmd({ "BufAdd" }, {
 		callback = function(g)
-			self:on_buffer_added(g.buf) -- Use self instead of M
+			self:on_buffer_added(g.buf)
 		end,
 	})
 	vim.api.nvim_create_autocmd({ "BufDelete" }, {
@@ -25,6 +25,16 @@ function M:init()
 			self:on_buffer_entered(g.buf)
 		end,
 	})
+
+	vim.api.nvim_create_autocmd({ "BufModifiedSet" }, {
+		callback = function(args)
+			local buf_id = args.buf
+			if self:has_buffer(buf_id) then
+				local is_modified = vim.api.nvim_buf_get_option(buf_id, "modified")
+				self:on_buffer_modified(buf_id, is_modified)
+			end
+		end,
+	})
 	setup_commands()
 	self:gather_buffers()
 end
@@ -33,30 +43,67 @@ function M:get_buffers()
 	return self.buffers
 end
 
+local function get_buffer_display_name(buf_id)
+	local name = vim.api.nvim_buf_get_name(buf_id)
+
+	if name ~= "" then
+		return name
+	end
+	return "[No Name]"
+end
+
+function M:on_buffer_modified(buf_id, is_modified)
+	for _, buf in ipairs(self.buffers) do
+		if buf.id == buf_id then
+			buf.modified = is_modified
+			break
+		end
+	end
+end
+
+local function is_empty_modified_buffer(buf_id)
+	local name = vim.api.nvim_buf_get_name(buf_id)
+	local modified = vim.api.nvim_buf_get_option(buf_id, "modified")
+	local line_count = vim.api.nvim_buf_line_count(buf_id)
+	return name == "" and line_count <= 1 and not modified
+end
+
 function M:gather_buffers()
 	self.buffers = {}
-	for _, id in ipairs(vim.api.nvim_list_bufs()) do
-		if vim.api.nvim_buf_is_valid(id) then
-			local name = vim.api.nvim_buf_get_name(id)
-			if name ~= "" then
-				table.insert(self.buffers, {
-					id = id,
-					name = name,
-				})
-			end
+	for _, buf_id in ipairs(vim.api.nvim_list_bufs()) do
+		if vim.api.nvim_buf_is_valid(buf_id) then
+			local name = vim.api.nvim_buf_get_name(buf_id)
+			local display_name = get_buffer_display_name(buf_id)
+			table.insert(self.buffers, {
+				id = buf_id,
+				name = name,
+				display_name = display_name,
+				modified = vim.api.nvim_buf_get_option(buf_id, "modified"),
+			})
 		end
 	end
 end
 
 function M:on_buffer_added(id)
-	if vim.api.nvim_buf_is_valid(id) then
-		local name = vim.api.nvim_buf_get_name(id)
-		if name ~= "" and not self:has_buffer(id) then
-			table.insert(self.buffers, {
+	for i, buf in ipairs(self.buffers) do
+		if is_empty_modified_buffer(buf.id) then
+			self.buffers[i] = {
 				id = id,
-				name = name,
-			})
+				name = vim.api.nvim_buf_get_name(id),
+				display_name = get_buffer_display_name(id),
+				modified = vim.api.nvim_buf_get_option(id, "modified"),
+			}
+			return
 		end
+	end
+
+	if not self:has_buffer(id) then
+		table.insert(self.buffers, {
+			id = id,
+			name = vim.api.nvim_buf_get_name(id),
+			display_name = get_buffer_display_name(id),
+			modified = vim.api.nvim_buf_get_option(id, "modified"),
+		})
 	end
 end
 
@@ -67,6 +114,15 @@ function M:has_buffer(id)
 		end
 	end
 	return false
+end
+
+function M:clean_empty_buffers()
+	for i = #self.buffers, 1, -1 do
+		local buf = self.buffers[i]
+		if is_empty_modified_buffer(buf.id) then
+			table.remove(self.buffers, i)
+		end
+	end
 end
 
 function M:on_buffer_removed(id)
@@ -113,8 +169,10 @@ function M:print_buffers()
 	end
 
 	for i, buf in ipairs(self.buffers) do
-		local active_marker = (buf.id == self.active) and " *" or ""
-		message = message .. string.format("\n%2d: [%2d] %s%s\n", i, buf.id, buf.name, active_marker)
+		local active_marker = (buf.id == self.active) and "->" or ""
+		local modified_marker = buf.modified and "* " or ""
+		message = message
+			.. string.format("%s%s%2d: [%2d] %s\n", active_marker, modified_marker, i, buf.id, buf.display_name)
 	end
 
 	if message == "" then
@@ -123,4 +181,7 @@ function M:print_buffers()
 	vim.notify(message, vim.log.levels.INFO)
 end
 
+function M:teardown()
+	vim.api.nvim_clear_autocmds({ group = "streamline" })
+end
 return M


### PR DESCRIPTION
Completes #6 

I tweaked the buffer handling to include unnamed buffers (ie from `:enew`), but only until a new buffer is opened (at that point it replaces the empty buffer) if the unnamed buffer is unmodified, otherwise it keeps storing it

I added functionality to track the modified state of buffers, via `BufModifiedSet` hook

I also tweaked print_buffers to show a marker for modified buffers