### PR TITLE
Buffer Navigation & Internal Buffer Architecture Refactor

### DIFF
--- a/lua/streamline/core.lua
+++ b/lua/streamline/core.lua
@@ -1,13 +1,36 @@
 local M = {
 	buffers = {},
-	active = nil,
+	active_buf = nil,
+	previous_buf = nil,
 	ignore_buftypes = { "quickfix", "nofile" },
+	navigating = false,
 }
 
-local function setup_commands()
+local function setup_commands(m)
 	vim.api.nvim_create_user_command("StreamBuffers", function()
 		require("streamline.ui"):print_buffers()
 	end, { desc = "Print current buffer list" })
+
+	vim.api.nvim_create_user_command("StreamNavBackward", function()
+		m:navigate_backward()
+	end, { desc = "Navigate backward in buffer list" })
+
+	vim.api.nvim_create_user_command("StreamNavForward", function()
+		m:navigate_forward()
+	end, { desc = "Navigate forward in buffer list" })
+
+	vim.api.nvim_create_user_command("StreamNavToPrevious", function()
+		m:navigate_to_previous()
+	end, { desc = "Navigate to previous buffer" })
+
+	vim.api.nvim_create_user_command("StreamNavToIndex", function(args)
+		local index = tonumber(args.args)
+		if index then
+			m:navigate_to_index(index)
+		else
+			vim.notify("[streamline] Invalid index", vim.log.levels.ERROR)
+		end
+	end, { desc = "Navigate to buffer at index", nargs = 1 })
 end
 
 function M:init()
@@ -49,18 +72,16 @@ function M:init()
 		group = self.augroup,
 		callback = function(args)
 			if self:has_buffer(args.buf) then
-				local buf = self:get_buffer(args.buf)
-				buf.display_name = self:get_buffer_display_name(args.buf)
+				self:get_buffer_by_id(args.buf).display_name = self:get_buffer_display_name(args.buf)
 			end
 		end,
 	})
 
-	setup_commands()
+	setup_commands(self)
 	self:gather_buffers()
-	self.active = vim.api.nvim_get_current_buf()
 end
 
-function M:get_buffer(buf_id)
+function M:get_buffer_by_id(buf_id)
 	for _, buf in ipairs(self.buffers) do
 		if buf.id == buf_id then
 			return buf
@@ -71,6 +92,14 @@ end
 
 function M:get_buffers()
 	return self.buffers
+end
+
+function M:get_buffer_index_from_id(buf_id)
+	for i, b in ipairs(self.buffers) do
+		if b.id == buf_id then
+			return i
+		end
+	end
 end
 
 function M:get_buffer_display_name(buf_id)
@@ -86,7 +115,7 @@ function M:get_buffer_display_name(buf_id)
 	return "[No Name]"
 end
 
-function M:create_buffer_entry(buf_id)
+function M:create_buffer_entry(buf_id, index)
 	local success, buf_name = pcall(vim.api.nvim_buf_get_name, buf_id)
 	if not success then
 		vim.notify("[streamline] Failed to get buffer name", vim.log.levels.ERROR)
@@ -96,6 +125,7 @@ function M:create_buffer_entry(buf_id)
 	return {
 		id = buf_id,
 		name = buf_name,
+		index = index,
 		display_name = self:get_buffer_display_name(buf_id),
 		modified = vim.bo[buf_id].modified,
 	}
@@ -154,12 +184,15 @@ function M:gather_buffers()
 		return
 	end
 
-	for _, buf_id in ipairs(buf_list) do
+	for i, buf_id in ipairs(buf_list) do
 		if vim.api.nvim_buf_is_valid(buf_id) then
 			local bt = vim.bo[buf_id].buftype
 			if not vim.tbl_contains(self.ignore_buftypes, bt) then
-				local new_buf = self:create_buffer_entry(buf_id)
+				local new_buf = self:create_buffer_entry(buf_id, i)
 				if new_buf then
+					if new_buf.id == vim.api.nvim_get_current_buf() then
+						self:set_active_buffer_by_index(new_buf.index)
+					end
 					table.insert(self.buffers, new_buf)
 				end
 			end
@@ -174,7 +207,7 @@ function M:on_buffer_added(id)
 	end
 	for i, buf in ipairs(self.buffers) do
 		if is_empty_modified_buffer(buf.id) then
-			local new_buf = self:create_buffer_entry(id)
+			local new_buf = self:create_buffer_entry(id, i)
 			if new_buf then
 				self.buffers[i] = new_buf
 			end
@@ -183,7 +216,7 @@ function M:on_buffer_added(id)
 	end
 
 	if not self:has_buffer(id) then
-		local new_buf = self:create_buffer_entry(id)
+		local new_buf = self:create_buffer_entry(id, #self.buffers + 1)
 		if new_buf then
 			table.insert(self.buffers, new_buf)
 		end
@@ -191,7 +224,7 @@ function M:on_buffer_added(id)
 end
 
 function M:has_buffer(id)
-	return self:get_buffer(id) ~= nil
+	return self:get_buffer_by_id(id) ~= nil
 end
 
 function M:clean_empty_buffers()
@@ -211,8 +244,11 @@ function M:on_buffer_removed(id)
 				vim.notify("[streamline] Failed to remove buffer from list", vim.log.levels.ERROR)
 				self:gather_buffers()
 			end
-			if self.active == id then
-				self.active = nil
+			if self.active_buf and self.active_buf.id == id then
+				self:set_active_buffer(nil)
+			end
+			if self.previous_buf and self.previous_buf.id == id then
+				self:set_previous_buffer(nil)
 			end
 			return
 		end
@@ -220,34 +256,109 @@ function M:on_buffer_removed(id)
 end
 
 function M:on_buffer_entered(id)
-	if vim.api.nvim_buf_is_valid(id) and self:has_buffer(id) then
-		self.active = id
+	if self.navigating then
+		self.navigating = false
+		local index = self:get_buffer_index_from_id(id)
+		if index then
+			self:set_active_buffer_by_index(index)
+		end
+		return
 	end
+
+	if vim.api.nvim_buf_is_valid(id) then
+		self:set_previous_buffer(self:get_active_buffer())
+		local index = self:get_buffer_index_from_id(id)
+		if index then
+			self:set_active_buffer_by_index(index)
+		end
+	end
+end
+
+function M:set_active_buffer(buf)
+	self.active_buf = buf
+end
+
+function M:set_active_buffer_by_index(index)
+	local buf = nil
+	for _, b in ipairs(self.buffers) do
+		if b.index == index then
+			buf = b
+			break
+		end
+	end
+	self:set_active_buffer(buf)
 end
 
 function M:get_active_buffer()
-	if not self.active then
-		return nil
-	end
-	for _, buf in ipairs(self.buffers) do
-		if buf.id == self.active then
-			return buf
-		end
-	end
-	return nil
+	return self.active_buf
 end
 
-function M:get_active_index()
-	if not self.active then
-		return nil
+function M:get_previous_buffer()
+	return self.previous_buf
+end
+
+function M:set_previous_buffer(buf)
+	self.previous_buf = buf
+end
+
+function M:navigate_backward()
+	if self:get_active_buffer() == nil then
+		return
 	end
 
-	for i, buf in ipairs(self.buffers) do
-		if buf.id == self.active then
-			return i
-		end
+	local index = self:get_buffer_index_from_id(self:get_active_buffer().id)
+	if index == 1 then
+		self:navigate_to_index(#self.buffers)
+	elseif index > 1 then
+		self:navigate_to_index(index - 1)
 	end
-	return nil
+end
+
+function M:navigate_forward()
+	if self:get_active_buffer() == nil then
+		return
+	end
+
+	local index = self:get_buffer_index_from_id(self:get_active_buffer().id)
+	if index == #self.buffers then
+		self:navigate_to_index(1)
+	elseif index < #self.buffers then
+		self:navigate_to_index(index + 1)
+	end
+end
+
+function M:navigate_to_index(index)
+	if not index or index < 1 or index > #self.buffers then
+		return
+	end
+
+	local new_buf = self.buffers[index]
+	if not new_buf then
+		return
+	end
+
+	self.navigating = true
+
+	if self.active_buf and self.active_buf.id ~= new_buf.id then
+		self:set_previous_buffer(self.active_buf)
+	end
+
+	self.active_buf = new_buf
+	vim.api.nvim_set_current_buf(new_buf.id)
+end
+
+function M:navigate_to_previous()
+	if not self.previous_buf or not vim.api.nvim_buf_is_valid(self.previous_buf.id) then
+		vim.notify("[streamline] No previous buffer to switch to", vim.log.levels.WARN)
+		return
+	end
+
+	local prev_index = self:get_buffer_index_from_id(self.previous_buf.id)
+	if prev_index then
+		self:navigate_to_index(prev_index)
+	else
+		vim.notify("[streamline] Previous buffer no longer in list", vim.log.levels.WARN)
+	end
 end
 
 function M:teardown()

--- a/lua/streamline/ui.lua
+++ b/lua/streamline/ui.lua
@@ -6,35 +6,38 @@ function M:print_buffers()
 	local active_buf = core.active_buf
 	local previous_buf = core.previous_buf
 
-	if active_buf and active_buf.index then
-		message = string.format("Active buffer: %d/%d\n", active_buf.index, #core.buffers)
+	local buffer_order = core.buffer_order
+	local buffers = core.buffers
+	print(vim.inspect(buffer_order))
+
+	if active_buf then
+		local active_index = core:get_buffer_index_from_id(active_buf.id)
+		message = string.format("Active buffer: %d/%d\n", active_index or 0, #buffer_order)
 	end
 
-	if previous_buf and previous_buf.index then
-		message = message .. string.format("Previous buffer: %d/%d\n", previous_buf.index, #core.buffers)
+	if previous_buf then
+		local prev_index = core:get_buffer_index_from_id(previous_buf.id)
+		message = message .. string.format("Previous buffer: %d/%d\n", prev_index or 0, #buffer_order)
 	end
 
-	for i, buf in ipairs(core.buffers) do
-		local active_marker = ""
-		local previous_marker = ""
+	for i, buf_id in ipairs(buffer_order) do
+		local buf = buffers[buf_id]
+		if buf then
+			local active_marker = (active_buf and buf.id == active_buf.id) and "> " or ""
+			local previous_marker = (previous_buf and buf.id == previous_buf.id) and "~ " or ""
+			local modified_marker = buf.modified and "* " or ""
 
-		if active_buf then
-			active_marker = (buf.id == active_buf.id) and "> " or ""
+			message = message
+				.. string.format(
+					"%s%s %-3d [%2d] %-40s %s\n",
+					active_marker,
+					previous_marker,
+					i,
+					buf.id,
+					buf.display_name,
+					modified_marker
+				)
 		end
-		if previous_buf then
-			previous_marker = (buf.id == previous_buf.id) and "~ " or ""
-		end
-		local modified_marker = buf.modified and "* " or ""
-		message = message
-			.. string.format(
-				"%s%s %-3d [%2d] %-40s %s\n",
-				active_marker,
-				previous_marker,
-				i,
-				buf.id,
-				buf.display_name,
-				modified_marker
-			)
 	end
 
 	if message == "" then

--- a/lua/streamline/ui.lua
+++ b/lua/streamline/ui.lua
@@ -3,16 +3,38 @@ local M = {}
 function M:print_buffers()
 	local message = ""
 	local core = require("streamline.core")
-	local active_idx = core:get_active_index()
-	if active_idx then
-		message = string.format("Active buffer: %d/%d\n", active_idx, #core.buffers)
+	local active_buf = core.active_buf
+	local previous_buf = core.previous_buf
+
+	if active_buf and active_buf.index then
+		message = string.format("Active buffer: %d/%d\n", active_buf.index, #core.buffers)
+	end
+
+	if previous_buf and previous_buf.index then
+		message = message .. string.format("Previous buffer: %d/%d\n", previous_buf.index, #core.buffers)
 	end
 
 	for i, buf in ipairs(core.buffers) do
-		local active_marker = (buf.id == core.active) and "->" or ""
+		local active_marker = ""
+		local previous_marker = ""
+
+		if active_buf then
+			active_marker = (buf.id == active_buf.id) and "> " or ""
+		end
+		if previous_buf then
+			previous_marker = (buf.id == previous_buf.id) and "~ " or ""
+		end
 		local modified_marker = buf.modified and "* " or ""
 		message = message
-			.. string.format("%s %-3d [%2d] %-40s %s\n", active_marker, i, buf.id, buf.display_name, modified_marker)
+			.. string.format(
+				"%s%s %-3d [%2d] %-40s %s\n",
+				active_marker,
+				previous_marker,
+				i,
+				buf.id,
+				buf.display_name,
+				modified_marker
+			)
 	end
 
 	if message == "" then


### PR DESCRIPTION
## New features
I implemented buffer navigation via the commands: 
```lua
:StreamNavBackward  -- Navigate to the previous buffer in the ordered list
:StreamNavForward -- Navigate to the next buffer in the ordered list
:StreamNavToPrevious -- Switch to the last active buffer
:StreamNavToIndex {n} --  Jump to the buffer at index n
```

## Architecture Changes
- Buffers are now stored in a two-part system:
  - buffers: a dictionary keyed by buffer ID, holding buffer metadata
  - buffer_order: a list representing the navigation order of buffers
- Indexes are dynamically updated on buffer events (BufAdd, BufDelete, BufEnter)
- This required a significant refactor to support both efficient access and ordered operations.

Completes Issue #3 