### PR TITLE
Implement buffer reordering: swap and reinsert commands

### DIFF
--- a/lua/streamline/ui.lua
+++ b/lua/streamline/ui.lua
@@ -8,7 +8,6 @@ function M:print_buffers()
 
 	local buffer_order = core.buffer_order
 	local buffers = core.buffers
-	print(vim.inspect(buffer_order))
 
 	if active_buf then
 		local active_index = core:get_buffer_index_from_id(active_buf.id)


### PR DESCRIPTION
This PR introduces new functionality for buffer reordering in the navigation list.

## New commands:
```lua
:StreamSwapBufferBefore     -- Swap the active buffer with the one before it (wraps around)
:StreamSwapBufferAfter      -- Swap the active buffer with the one after it (wraps around)
:StreamSwapBufferWith {id1} {id2} -- Swap two buffers by buffer ID

:StreamReinsertBufferBeforeIndex {from_index} {to_index}
:StreamReinsertBufferAfterIndex  {from_index} {to_index}

:StreamResinsertBufferBeforeById {from_id} {to_id}
:StreamResinsertBufferAfterById  {from_id} {to_id}
```

These allow fine-grained control over buffer positioning in the buffer_order list, useful for both user control and plugin integrations.

## Architectural Notes

- Reordering logic updates buffer_order and reindexes buffers consistently.
- Reinsertion and swap logic are strict about distinguishing between buffer index and buffer ID, to avoid ambiguity and unintended side effects.
- All commands perform input validation and provide helpful error messages when inputs are invalid or missing.

Closes #4.
Builds on #3.