### PR TITLE
fix: fixed bug in update_indices on empty active or previous buffer

### DIFF
--- a/lua/streamline/core.lua
+++ b/lua/streamline/core.lua
@@ -243,8 +243,12 @@ local function update_indices(self)
 		end
 	end
 
-	self.active_buf = self.buffers[self.active_buf.id]
-	self.previous_buf = self.buffers[self.previous_buf.id]
+	if self.active_buf then
+		self.active_buf = self.buffers[self.active_buf.id]
+	end
+	if self.previous_buf then
+		self.previous_buf = self.buffers[self.previous_buf.id]
+	end
 end
 
 function M:on_buffer_modified(buf_id, is_modified)


### PR DESCRIPTION
I fixed a bug in update_indices where an error throws when there is no active or previous buffer. I added 2 if statements to only update active and previous buffer when available

Closes #19. 
Originally from #4.