### PR TITLE
Add Configurable Buffer Insertion Behavior

### DIFF
--- a/lua/streamline/core.lua
+++ b/lua/streamline/core.lua
@@ -311,28 +311,28 @@ function M:gather_buffers()
 	update_indices(self)
 end
 
-function M:on_buffer_added(id)
-	local bt = vim.bo[id].buftype
+function M:on_buffer_added(buf_id)
+	local bt = vim.bo[buf_id].buftype
 	if vim.tbl_contains(self.ignore_buftypes, bt) then
 		return
 	end
 
-	for buf_id, buf in pairs(self.buffers) do
-		if is_empty_modified_buffer(buf_id) then
-			self.buffers[buf_id] = self:create_buffer_entry(id)
-			self.buffer_order[buf.index] = id
-			update_indices(self)
-			return
+	local new_buf = self:create_buffer_entry(buf_id)
+	if new_buf then
+		self.buffers[buf_id] = new_buf
+		if self.config.default_insert_behavior == "beginning" then
+			table.insert(self.buffer_order, 1, buf_id)
+		elseif self.config.default_insert_behavior == "end" then
+			table.insert(self.buffer_order, buf_id)
+		elseif self.config.default_insert_behavior == "before" then
+			local target_index = self.active_buf and self:get_buffer_index_from_id(self.active_buf.id) or 1
+			table.insert(self.buffer_order, target_index, buf_id)
+		elseif self.config.default_insert_behavior == "after" then
+			local target_index = self.active_buf and self:get_buffer_index_from_id(self.active_buf.id) + 1
+				or #self.buffer_order + 1
+			table.insert(self.buffer_order, target_index, buf_id)
 		end
-	end
-
-	if not self.buffers[id] then
-		local new_buf = self:create_buffer_entry(id)
-		if new_buf then
-			self.buffers[id] = new_buf
-			table.insert(self.buffer_order, id)
-			update_indices(self)
-		end
+		update_indices(self)
 	end
 end
 

--- a/lua/streamline/core.lua
+++ b/lua/streamline/core.lua
@@ -5,6 +5,9 @@ local M = {
 	previous_buf = nil,
 	ignore_buftypes = { "quickfix", "nofile" },
 	navigating = false,
+	config = {
+		default_insert_behavior = "end",
+	},
 }
 
 local function setup_commands(m)

--- a/lua/streamline/init.lua
+++ b/lua/streamline/init.lua
@@ -1,7 +1,13 @@
 local M = {}
 
 local core = require("streamline.core")
-function M.setup()
+
+function M.setup(opts)
+	opts = opts or {}
+	core.config = vim.tbl_extend("force", {
+		default_insert_behavior = "end",
+	}, opts)
+
 	core:init()
 end
 


### PR DESCRIPTION
## Summary
This PR introduces configurable buffer insertion behavior, allowing users to control where new buffers are placed in the buffer_order list relative to the current buffer.

Closes #2 

## Features Added
Introduced a new config option:
```lua
default_insert_behavior = "end" -- one of: "beginning", "end", "before", "after"
```
New buffers are inserted at the location defined by default_insert_behavior:

- "beginning": New buffers are inserted at the start of the list
- "end" (default): New buffers are inserted at the end
- "before": Inserted directly before the active buffer
- "after": Inserted directly after the active buffer

## Notes
- If vim itself replaces a buffer (e.g. [No Name] becomes a real buffer), streamline correctly reflects this change in the buffer list.
- Insert logic is centralized in on_buffer_added
- Buffer replacement is not controlled by this setting, but respects Neovim's default behavior
- update_indices() ensures all buffer entries remain in sync after insertion

## Example Usage (neovim config)

```lua
require("streamline").setup({
  default_insert_behavior = "before", -- user can override default here
})
```