### PR TITLE
bugfix: fixed bugs after refactor

### DIFF
--- a/lua/streamline/core/navigation.lua
+++ b/lua/streamline/core/navigation.lua
@@ -41,7 +41,7 @@ function M:navigate_to_index(index)
 	core:set_is_navigating(true)
 
 	if core:get_active_buf() and core:get_active_buf_index() ~= new_buf_id then
-		core.set_previous_buf(core:get_active_buf())
+		core:set_previous_buf(core:get_active_buf())
 	end
 
 	local new_buf = core:get_buffer_by_id(new_buf_id)


### PR DESCRIPTION
## Summary
This PR resolves two issues introduced during recent refactoring:

## Fixes
### [No Name] Buffers Were Not Properly Replaced
When opening a new file while the current buffer is an unnamed [No Name] buffer, the expected behavior is for the new buffer to "replace" the [No Name] one.
#### Issue:
Previously, the [No Name] buffer remained in the buffer_order but its data in buffers was never updated, resulting in inconsistent state and navigation errors.
#### Fix:
We now detect this case in on_buffer_entered by comparing the current display name with the newly resolved buffer name. If the display name has changed (i.e., the buffer has become a real file), we recreate the buffer entry and update the tracking.

### `previous_buf` Was No Longer Being Tracked
#### Issue:
`previous_buf` was not being updated during navigation or buffer switches, especially when entering a new buffer or switching via APIs.

#### Fix:
Updated on_buffer_entered to properly assign `previous_buf` before switching to the new active buffer. Also removed redundant or misplaced buffer reassignments that prevented `previous_buf` from staying accurate.


## Other Notes

- Removed deferred logic around [No Name] buffer deletion in favor of direct checks to avoid flakiness and fix failing tests.
- Tests now pass and buffer state is consistent after navigating, replacing, or deleting buffers.

Introduced in: #27 
Completes: #29 
